### PR TITLE
ci: fix changesets publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: changesets/action@v1
         with:
-          publish: yarn build:packages && scripts/publish.sh
+          publish: yarn publish:packages
           commit: "chore: version packages"
           title: "chore: version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "nx run-many -t dev",
     "build": "nx run-many -t build",
     "build:packages": "nx run-many -t build --projects='packages/*'",
+    "publish:packages": "yarn build:packages && scripts/publish.sh",
     "lint": "nx run-many -t lint -- --max-warnings=0",
     "test": "nx run-many -t test",
     "postinstall": "husky"


### PR DESCRIPTION
Using "&&" in changesets action publish command will pass the subsequent command as additional flags to NX for some reason.