### PR TITLE
refactor!: rename action hooks

### DIFF
--- a/.changeset/nice-adults-decide.md
+++ b/.changeset/nice-adults-decide.md
@@ -1,0 +1,10 @@
+---
+"@reactive-dot/react": minor
+---
+
+**BREAKING**: rename action hooks
+
+- `useResetQueryError` to `useQueryErrorResetter`
+- `useConnectWallet` to `useWalletConnector`
+- `useDisconnectWallet` to `useWalletDisconnector`
+- `useReconnectWallets` to `useWalletsReconnector`

--- a/apps/docs/docs/getting-started/connect-wallets.mdx
+++ b/apps/docs/docs/getting-started/connect-wallets.mdx
@@ -78,15 +78,16 @@ export const config = {
 import {
   useConnectedWallets,
   useWallets,
-  useConnectWallet,
+  useWalletConnector,
+  useWalletDisconnector,
 } from "@reactive-dot/react";
 
 export function Wallets() {
   const wallets = useWallets();
   const connectedWallets = useConnectedWallets();
 
-  const [_, connectWallet] = useConnectWallet();
-  const [__, disconnectWallet] = useDisconnectWallet();
+  const [_, connectWallet] = useWalletConnector();
+  const [__, disconnectWallet] = useWalletDisconnector();
 
   return (
     <section>

--- a/apps/docs/docs/getting-started/query.md
+++ b/apps/docs/docs/getting-started/query.md
@@ -203,10 +203,10 @@ function QueryWithRefresh() {
 
 ## Retry failed query
 
-Error from queries can be caught and reset using `ErrorBoundary` & [`useResetQueryError`](/api/react/function/useResetQueryError) hook.
+Error from queries can be caught and reset using `ErrorBoundary` & [`useQueryErrorResetter`](/api/react/function/useQueryErrorResetter) hook.
 
 ```tsx
-import { useResetQueryError } from "@reactive-dot/react";
+import { useQueryErrorResetter } from "@reactive-dot/react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 function ErrorFallback(props: FallbackProps) {
@@ -221,7 +221,7 @@ function ErrorFallback(props: FallbackProps) {
 }
 
 function AppErrorBoundary() {
-  const resetQueryError = useResetQueryError();
+  const resetQueryError = useQueryErrorResetter();
 
   return (
     <ErrorBoundary

--- a/apps/example/src/app.tsx
+++ b/apps/example/src/app.tsx
@@ -6,15 +6,15 @@ import {
   ReDotProvider,
   useAccounts,
   useBlock,
-  useConnectWallet,
   useConnectedWallets,
-  useDisconnectWallet,
   useLazyLoadQuery,
   useLazyLoadQueryWithRefresh,
   useMutation,
   useMutationEffect,
   useNativeTokenAmountFromPlanck,
-  useResetQueryError,
+  useQueryErrorResetter,
+  useWalletConnector,
+  useWalletDisconnector,
   useWallets,
 } from "@reactive-dot/react";
 import { formatDistance } from "date-fns";
@@ -171,8 +171,8 @@ type WalletItemProps = {
 function WalletItem(props: WalletItemProps) {
   const connectedWallets = useConnectedWallets();
 
-  const [connectingState, connect] = useConnectWallet(props.wallet);
-  const [disconnectingState, disconnect] = useDisconnectWallet(props.wallet);
+  const [connectingState, connect] = useWalletConnector(props.wallet);
+  const [disconnectingState, disconnect] = useWalletDisconnector(props.wallet);
 
   return (
     <li>
@@ -316,7 +316,7 @@ function ErrorFallback(props: FallbackProps) {
 type ExampleProps = { chainName: string };
 
 function Example(props: ExampleProps) {
-  const resetQueryError = useResetQueryError();
+  const resetQueryError = useQueryErrorResetter();
 
   useMutationEffect((event) => {
     if (event.value === PENDING) {

--- a/packages/react/src/contexts/index.tsx
+++ b/packages/react/src/contexts/index.tsx
@@ -1,4 +1,4 @@
-import { useReconnectWallets } from "../hooks/use-reconnect-wallets.js";
+import { useWalletsReconnector } from "../hooks/use-wallets-reconnector.js";
 import { chainConfigsAtom } from "../stores/config.js";
 import { aggregatorsAtom, directWalletsAtom } from "../stores/wallets.js";
 import { MutationEventSubjectContext } from "./mutation.js";
@@ -62,7 +62,7 @@ function ReDotHydrator(props: ReDotProviderProps) {
 }
 
 function WalletsReconnector() {
-  const [_, reconnect] = useReconnectWallets();
+  const [_, reconnect] = useWalletsReconnector();
 
   useEffect(() => {
     reconnect();

--- a/packages/react/src/hooks/use-query-error-resetter.ts
+++ b/packages/react/src/hooks/use-query-error-resetter.ts
@@ -5,6 +5,6 @@ import { resetQueryError } from "../utils/jotai.js";
  *
  * @returns Function to reset caught query error
  */
-export function useResetQueryError() {
+export function useQueryErrorResetter() {
   return resetQueryError;
 }

--- a/packages/react/src/hooks/use-wallet-connector.ts
+++ b/packages/react/src/hooks/use-wallet-connector.ts
@@ -11,7 +11,7 @@ import { useCallback } from "react";
  * @param wallets - Wallets to connect to, will connect to all available wallets if none is specified
  * @returns The wallet connection state & connect function
  */
-export function useConnectWallet(wallets?: Wallet | Wallet[]) {
+export function useWalletConnector(wallets?: Wallet | Wallet[]) {
   const hookWallets = wallets;
 
   const [success, setSuccess] = useAsyncState<true>();

--- a/packages/react/src/hooks/use-wallet-disconnector.ts
+++ b/packages/react/src/hooks/use-wallet-disconnector.ts
@@ -11,7 +11,7 @@ import { useCallback } from "react";
  * @param wallets - Wallets to disconnect from, will disconnect from all connected wallets if none is specified
  * @returns The wallet disconnection state & disconnect function
  */
-export function useDisconnectWallet(wallets?: Wallet | Wallet[]) {
+export function useWalletDisconnector(wallets?: Wallet | Wallet[]) {
   const hookWallets = wallets;
 
   const [success, setSuccess] = useAsyncState<true>();

--- a/packages/react/src/hooks/use-wallets-reconnector.ts
+++ b/packages/react/src/hooks/use-wallets-reconnector.ts
@@ -13,7 +13,7 @@ import { useCallback, useState } from "react";
  *
  * @returns The reconnection state and reconnect function
  */
-export function useReconnectWallets() {
+export function useWalletsReconnector() {
   const wallets = useWallets();
 
   const [state, setState] = useState<AsyncValue<true, ReDotError>>(IDLE);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,20 +12,20 @@ export { useBlock } from "./hooks/use-block.js";
 export { useChainId } from "./hooks/use-chain-id.js";
 export { useChainSpecData } from "./hooks/use-chain-spec-data.js";
 export { useClient } from "./hooks/use-client.js";
-export { useConnectWallet } from "./hooks/use-connect-wallet.js";
-export { useDisconnectWallet } from "./hooks/use-disconnect-wallet.js";
 export { useMutationEffect } from "./hooks/use-mutation-effect.js";
 export { useMutation } from "./hooks/use-mutation.js";
 export {
   useNativeTokenAmountFromNumber,
   useNativeTokenAmountFromPlanck,
 } from "./hooks/use-native-token-amount.js";
+export { useQueryErrorResetter } from "./hooks/use-query-error-resetter.js";
 export {
   useLazyLoadQuery,
   useLazyLoadQueryWithRefresh,
   useQueryRefresher,
 } from "./hooks/use-query.js";
-export { useReconnectWallets } from "./hooks/use-reconnect-wallets.js";
-export { useResetQueryError } from "./hooks/use-reset-query-error.js";
 export { useTypedApi } from "./hooks/use-typed-api.js";
+export { useWalletConnector } from "./hooks/use-wallet-connector.js";
+export { useWalletDisconnector } from "./hooks/use-wallet-disconnector.js";
+export { useWalletsReconnector } from "./hooks/use-wallets-reconnector.js";
 export { useConnectedWallets, useWallets } from "./hooks/use-wallets.js";


### PR DESCRIPTION
- `useResetQueryError` to `useQueryErrorResetter`
- `useConnectWallet` to `useWalletConnector`
- `useDisconnectWallet` to `useWalletDisconnector`
- `useReconnectWallets` to `useWalletsReconnector`