### PR TITLE
fix: use `const` modifier

### DIFF
--- a/.changeset/short-cobras-complain.md
+++ b/.changeset/short-cobras-complain.md
@@ -1,0 +1,5 @@
+---
+"@reactive-dot/react": patch
+---
+
+Use `const` modifier in case consuming applications also perform checks on library types.

--- a/packages/react/src/hooks/use-balance.ts
+++ b/packages/react/src/hooks/use-balance.ts
@@ -56,7 +56,7 @@ export function useSpendableBalance(
       builder.getConstant("Balances", "ExistentialDeposit").readStorages(
         "System",
         "Account",
-        addresses.map((address) => [address]),
+        addresses.map((address) => [address] as const),
       ),
     options,
   ) as [bigint, SystemAccount[]];


### PR DESCRIPTION
In case consuming applications also perform checks on library types.