### PR TITLE
ci: don't use parallel execution for versioning packages

### DIFF
--- a/.github/workflows/snapshot-publishing.yml
+++ b/.github/workflows/snapshot-publishing.yml
@@ -19,7 +19,7 @@ jobs:
 
       - run: yarn build:packages
 
-      - run: yarn workspaces foreach -Apt --no-private version 0.0.0-snapshot.${{ github.run_number }}+$(git rev-parse --short HEAD) --immediate
+      - run: yarn workspaces foreach -At --no-private version 0.0.0-snapshot.${{ github.run_number }}+$(git rev-parse --short HEAD) --immediate
 
       - run: scripts/publish-snapshot.sh
         env:


### PR DESCRIPTION
This caused intermittent failure.