### PR TITLE
refactor: optimize query and query-refresher logic

### DIFF
--- a/.changeset/lovely-camels-tie.md
+++ b/.changeset/lovely-camels-tie.md
@@ -1,0 +1,5 @@
+---
+"@reactive-dot/react": patch
+---
+
+Refactored query & query-refresher logic.

--- a/packages/react/src/hooks/use-query-refresher.ts
+++ b/packages/react/src/hooks/use-query-refresher.ts
@@ -1,0 +1,67 @@
+import { getQueryInstructionPayloadAtoms } from "../stores/query.js";
+import type { Falsy } from "../types.js";
+import type { ChainHookOptions } from "./types.js";
+import { internal_useChainId } from "./use-chain-id.js";
+import { useConfig } from "./use-config.js";
+import {
+  Query,
+  type ChainId,
+  type Chains,
+  type CommonDescriptor,
+} from "@reactive-dot/core";
+import type { QueryInstruction } from "@reactive-dot/core/internal.js";
+import { useAtomCallback } from "jotai/utils";
+import { useCallback } from "react";
+
+/**
+ * Hook for refreshing cached query.
+ *
+ * @param builder - The function to create the query
+ * @param options - Additional options
+ * @returns The function to refresh the query
+ */
+export function useQueryRefresher<
+  TQuery extends
+    | ((
+        builder: Query<[], TDescriptor>,
+      ) => Query<QueryInstruction<TDescriptor>[], TDescriptor> | Falsy)
+    | Falsy,
+  TDescriptor extends TChainId extends void
+    ? CommonDescriptor
+    : Chains[TChainId],
+  TChainId extends ChainId,
+>(builder: TQuery, options?: ChainHookOptions<TChainId>) {
+  const config = useConfig();
+  const chainId = internal_useChainId(options);
+
+  const refresh = useAtomCallback(
+    useCallback(
+      (_, set) => {
+        if (!builder) {
+          return;
+        }
+
+        const query = builder(new Query([]));
+
+        if (!query) {
+          return;
+        }
+
+        const atoms = getQueryInstructionPayloadAtoms(
+          config,
+          chainId,
+          query,
+        ).flat();
+
+        for (const atom of atoms) {
+          if ("write" in atom) {
+            set(atom);
+          }
+        }
+      },
+      [builder, chainId, config],
+    ),
+  );
+
+  return refresh;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,10 +22,10 @@ export {
 } from "./hooks/use-native-token-amount.js";
 export { useQueryErrorResetter } from "./hooks/use-query-error-resetter.js";
 export { useQueryLoader } from "./hooks/use-query-loader.js";
+export { useQueryRefresher } from "./hooks/use-query-refresher.js";
 export {
   useLazyLoadQuery,
   useLazyLoadQueryWithRefresh,
-  useQueryRefresher,
 } from "./hooks/use-query.js";
 export { useSigner } from "./hooks/use-signer.js";
 export { useTypedApi } from "./hooks/use-typed-api.js";


### PR DESCRIPTION
Removed redundant refresh hook when only data fetching is required.