### PR TITLE
refactor(react): wrap context providers with Jotai's `Provider`

### DIFF
--- a/.changeset/shaky-peas-sit.md
+++ b/.changeset/shaky-peas-sit.md
@@ -1,0 +1,5 @@
+---
+"@reactive-dot/react": patch
+---
+
+Fixed a potential issue where states could leak in a Server-Side Rendering (SSR) environment.

--- a/packages/react/src/contexts/provider.tsx
+++ b/packages/react/src/contexts/provider.tsx
@@ -2,6 +2,7 @@ import { useWalletsInitializer } from "../hooks/use-wallets-initializer.js";
 import { ConfigContext } from "./config.js";
 import { MutationEventSubjectContext } from "./mutation.js";
 import type { Config } from "@reactive-dot/core";
+import { Provider as JotaiProvider } from "jotai";
 import { type PropsWithChildren, Suspense, useEffect, useMemo } from "react";
 import { Subject } from "rxjs";
 
@@ -24,14 +25,16 @@ export function ReactiveDotProvider({
   children,
 }: ReactiveDotProviderProps) {
   return (
-    <ConfigContext value={config}>
-      <MutationEventSubjectContext value={useMemo(() => new Subject(), [])}>
-        <Suspense>
-          <WalletsInitializer />
-        </Suspense>
-        {children}
-      </MutationEventSubjectContext>
-    </ConfigContext>
+    <JotaiProvider>
+      <ConfigContext value={config}>
+        <MutationEventSubjectContext value={useMemo(() => new Subject(), [])}>
+          <Suspense>
+            <WalletsInitializer />
+          </Suspense>
+          {children}
+        </MutationEventSubjectContext>
+      </ConfigContext>
+    </JotaiProvider>
   );
 }
 


### PR DESCRIPTION
This prevents leaking states in SSR environment.